### PR TITLE
Dont cat into grep

### DIFF
--- a/config/.zshrc
+++ b/config/.zshrc
@@ -47,7 +47,7 @@ complete -C $(which aws_completer) aws # tab compleition
 # Autocompletion is defined in ~/.oh-my-zsh/completions/_aws-user
 #
 function aws-users() {
-    cat ~/.aws/credentials | grep '\[' | grep -v '#' | tr -d '[' | tr -d ']'
+    grep '\[' ~/.aws/credentials | grep -v '#' | tr -d '[' | tr -d ']'
 };
 
 function aws-user () {


### PR DESCRIPTION
`grep` is able to take a file from STDIN, therefor you should use `cat`. Another thing is that doing `cat file | grep "something"` uses more CPU power than doing `grep "something" file`

Just a tip, when writing a script and you want to output the content of a file, use `< file` instead of `cat` as it is less resource intensive than `cat`